### PR TITLE
Add docker service deployment instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+dmarc-demo-data
+docker-volumes
+node_modules
+.git
+.DS_Store
+*.mmdb
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 GeoLite2-City.mmdb
 
 dmarc-demo-data/
+
+.docker-volumes/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,90 @@
+# Quickly deploy DMARC viewer with docker
+
+Make sure that you have [docker installed](https://www.docker.com/get-docker)
+on you system and use `docker-compose` to build and run two containers, one for
+the Django web app and one for the PostgreSQL database. If you prefer an *old
+school* setup, take a look at [`DEPLOYMENT.md`](DEPLOYMENT.md).
+
+## Variables
+On your host system, export these environment variables. They will be passed
+through to the docker containers to set passwords and
+[Django allowed hosts](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-ALLOWED_HOSTS).
+Don't forget to **replace the values**.
+
+```shell
+export DMARC_VIEWER_DB_KEY="**** REPLACE WITH DATABSE PASSWORD ****"
+export DMARC_VIEWER_SECRET_KEY="**** REPLACE WITH LARGE RANDOM STRING ****"
+export DMARC_VIEWER_ALLOWED_HOSTS="**** REPLACE WITH YOUR DOMAIN OR IP ****"
+```
+
+## Docker compose
+The following command will create and spin up docker services for the `DMARC
+viewer` Django web app and corresponding database. Take a look at
+[`docker-compose.yml`](docker-compose.yml), where both services are defined and
+[`Dockerfile`](Dockerfile) which lists the specific instructions for the web
+app setup.
+
+```shell
+# In the root of the project
+docker-compose up --build --detach
+```
+`DMARC viewer` should now be available at
+[`http://<your domain or IP>:8000`](http://localhost:8000).
+
+*NOTE: Both services will mount a volume to share files with your host system.
+This is useful to persist your database across re-starts of your containers
+and to make DMARC aggregate reports on your host system available to the
+containers.*
+
+
+## Import reports and default views
+Use `docker exec` to execute commands in your running containers, in order to
+parse DMARC aggregate reports into your database and/or import analysis views.
+
+
+### Analysis Views
+The following command creates three default analysis views. Take a look at
+[`ANALYSIS_VIEWS.md`](ANALYSIS_VIEWS.md) for more infos.
+```shell
+docker exec -it dmarc-viewer-app \
+    python manage.py loadviews demo/views.json
+```
+
+### Parse DMARC aggregate reports
+Move your reports to the `.docker-volumes/app` directory. It is mounted inside
+the web app's container `WORKDIR/shared` directory. Then run the following
+commands to download the required
+[`Maxmind GeoLite2 City`](http://geolite.maxmind.com/download/geoip/database)
+and parse your DMARC aggregate reports. Don't forget to **choose** the correct
+report `--type` and subdirectory. Take a look at [`REPORTS.md`](REPORTS.md) for
+more infos.
+
+```shell
+# Download and unzip Maxmind Geo IP database
+docker exec -it dmarc-viewer-app /bin/ash -c \
+    'wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz \
+    && gunzip GeoLite2-City.mmdb.gz'
+
+docker exec -it dmarc-viewer-app \
+     python manage.py parse --type [in | out] shared/<incoming | outgoing report subdir>
+```
+*NOTE: You can also mount a directory from your host system that already
+contains your DMARC aggregate reports. Take a look at
+[`docker volumes`](https://docs.docker.com/storage/volumes/) for further
+instructions.*
+
+## Stop and remove containers
+The following command stops and removes all running docker containers that have
+`dmarc-viewer` in their name, e.g. `dmarc-viewer-db` and `dmarc-viewer-app`.
+```shell
+docker rm $(docker stop $(docker ps -q -f "name=dmarc-viewer"))
+```
+
+## Troubleshooting
+Since you specified the `--detach` flag in the `docker-compose up` command
+above, logs won't be shown in your host terminal. Use the following command on
+your host system to see logs for both or one of the running containers.
+
+```shell
+ docker-compose logs [dmarc-viewer-app | dmarc-viewer-db]
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+# Dockerfile for DMARC viewer app
+# Use Alpine as stripped down OS
+FROM python:2.7-alpine
+
+# Copy in your requirements file
+ADD requirements.txt /requirements.txt
+
+# Install build deps, then run `pip install`, then remove unneeded build deps
+# all in a single step. Correct the path to your production requirements file,
+# if needed.
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+            gcc \
+            make \
+            libc-dev \
+            libffi-dev \
+            musl-dev \
+            linux-headers \
+            pcre-dev \
+            postgresql-dev \
+            libpq \
+            py-psycopg2 \
+            cairo-dev \
+    && pip install -U pip \
+    && pip install --no-cache-dir -r /requirements.txt \
+    && pip install --no-cache-dir uwsgi \
+    && find /usr/local \
+        \( -type d -a -name test -o -name tests \) \
+        -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+        -exec rm -rf '{}' +
+    # Commented code removes runtime dependencies `CairoSVG`
+    # FIXME: Find out how to detect those dependencies with scanelf
+    # && runDeps="$( \
+    #         scanelf --needed --nobanner --recursive /usr/local \
+    #                 | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+    #                 | sort -u \
+    #                 | xargs -r apk info --installed \
+    #                 | sort -u \
+    # )" \
+    # && apk add --virtual .python-rundeps $runDeps \
+    # && apk del .build-deps
+
+# Copy your application code to the container (make sure you create a
+# .dockerignore file if any large files or directories should be excluded)
+RUN mkdir /code/
+WORKDIR /code/
+ADD . /code/
+
+# uWSGI will listen on this port
+EXPOSE 8000
+
+# NOTE: Other user-set app environment variables (app key, db pw, ...) are
+# passed through from `docker-compose`. If you didn't create the container with
+# `docker-compose` you have to pass the required environment variables to
+# `docker run`, e.g. using the `-e` flag
+ENV DJANGO_SETTINGS_MODULE="dmarc_viewer.settings"
+
+# Configure uWSGI using environment variables
+# NOTE: When passed as environment variables, options are capitalized and
+# prefixed with UWSGI_, and dashes are substituted with underscores
+# See http://uwsgi-docs.readthedocs.io/en/latest/Options.html
+ENV UWSGI_WSGI_FILE=dmarc_viewer/wsgi.py \
+    UWSGI_HTTP=:8000 \
+    UWSGI_MASTER=1 \
+    UWSGI_WORKERS=2 \
+    UWSGI_THREADS=8 \
+    UWSGI_UID=1000 \
+    UWSGI_GID=2000 \
+    UWSGI_LAZY_APPS=1 \
+    UWSGI_WSGI_ENV_BEHAVIOR=holy \
+    UWSGI_HTTP_AUTO_CHUNKED=1 \
+    UWSGI_HTTP_KEEPALIVE=1 \
+    UWSGI_STATIC_MAP=/static=/var/www/dmarc_viewer/static
+
+ENTRYPOINT ["/code/docker-entrypoint.sh"]
+
+# Start uWSGI
+CMD ["uwsgi"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To analyze your own DMARC aggregate reports you need to deploy an instance of
  1. [import](REPORTS.md) DMARC aggregate reports,
  1. and [create `analysis views`](ANALYSIS_VIEWS.md).
 
+Alternatively you can deploy [`DMARC viewer` using docker](DOCKER.md).
+
 You'll find further usage instructions on the
 [`DMARC viewer` help page](https://dmarc-viewer.abteil.org/help/) and plenty of
 contextual help throughout the website (look out for "**`?`**" symbols).

--- a/dmarc_viewer/settings.py
+++ b/dmarc_viewer/settings.py
@@ -118,7 +118,7 @@ DATABASES = {
         'NAME': 'dmarc_viewer_db',
         'USER': 'dmarc_viewer_db',
         'PASSWORD': os.environ.get("DMARC_VIEWER_DB_KEY", ""),
-        'HOST': '127.0.0.1'
+        'HOST': os.environ.get("DMARC_VIEWER_DB_HOST", "127.0.0.1")
     }
 }
 
@@ -162,17 +162,17 @@ LOGGING = {
         'console': {
             'class': 'logging.StreamHandler',
         },
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'log/dmarc_viewer.log')
-        }
+        # 'file': {
+        #     'level': 'DEBUG',
+        #     'class': 'logging.FileHandler',
+        #     'filename': os.path.join(BASE_DIR, 'log/dmarc_viewer.log')
+        # }
     },
     'loggers': {
-        'parser': {
-            'handlers': ['file'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO')
-        },
+        # 'parser': {
+        #     'handlers': ['file'],
+        #     'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO')
+        # },
         'django': {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  dmarc-viewer-db:
+    # Docker container names must be unique
+    # If you plan on using more containers, remove `container_name`
+    # https://docs.docker.com/compose/compose-file/#container_name
+    container_name: dmarc-viewer-db
+    environment:
+      # User and db name defined in dmarc_viewer.settings.DATABASES
+      POSTGRES_DB: dmarc_viewer_db
+      POSTGRES_USER: dmarc_viewer_db
+      POSTGRES_PASSWORD: ${DMARC_VIEWER_DB_KEY}
+    restart: always
+    image: postgres:9.4
+    expose:
+      - "5432"
+    volumes:
+      # Persist container DB data in mounted host system directory
+      - "./.docker-volumes/db:/var/lib/postgresql/data"
+  dmarc-viewer-app:
+    # Docker container names must be unique
+    # If you plan on using more containers, remove `container_name`
+    # https://docs.docker.com/compose/compose-file/#container_name
+    container_name: dmarc-viewer-app
+    environment:
+      # Pass environment variables required in `dmarc_viewer.settings`
+      # Make sure these environment variables are available in the environment,
+      # where you run `docker-compose up`, i.e. your host system
+      - DMARC_VIEWER_DB_KEY
+      - DMARC_VIEWER_ALLOWED_HOSTS
+      - DMARC_VIEWER_SECRET_KEY
+      # The db service name (see above) can be used as path to access the db
+      - DMARC_VIEWER_DB_HOST=dmarc-viewer-db
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      # Mount read-only host system directory to access reports
+      - "./.docker-volumes/app:/code/shared:ro"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -x -e
+# Wait until DB is up
+# TODO: Is there a better way to check this?
+until python -c "import psycopg2; \
+                 psycopg2.connect( \
+                      dbname='dmarc_viewer_db', \
+                      user='dmarc_viewer_db', \
+                      host='${DMARC_VIEWER_DB_HOST}', \
+                      password='${DMARC_VIEWER_DB_KEY}')"; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+# NOTE: Below management commands are no-ops if they ran before
+# Populate initial DMARC viewer db model
+>&2 echo "Setup DB"
+python manage.py makemigrations website --noinput
+python manage.py migrate --noinput
+
+# Collect and copy required static web assets
+# (see sdmarc_viewer.ettings.STATIC_ROOT)
+>&2 echo "Collect and move static files"
+python manage.py collectstatic --noinput
+
+exec "$@"


### PR DESCRIPTION
Add instructions for deploying `DMARC viewer` and the corresponding database as docker services using `docker-compose`.

*Credits*
A blog post from [caktusgroup.com](https://www.caktusgroup.com/blog/2017/03/14/production-ready-dockerfile-your-python-django-app/) was used to get the setup started. Kudos also go to @andreasschulze for poking me with patches.

*Fixme*
There is potential for optimizing the container image size by removing build dependencies (see [`Dockerfile#L31-L41`](https://github.com/dmarc-viewer/dmarc-viewer/blob/dockerize/Dockerfile#L31-L41)).