### PR TITLE
Fix django_cache permission on docker (fix #10)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,4 +23,9 @@ python manage.py migrate --noinput
 >&2 echo "Collect and move static files"
 python manage.py collectstatic --noinput
 
+# Change cache dir ownership (see dmarc-viewer/dmarc-viewer#10)
+# The cache dir is created when running `makemigrations` above (as root), but
+# the uwsgi daemon is running with `UWSGI_UID` (see Dockerfile)
+chown ${UWSGI_UID} /var/tmp/django_cache
+
 exec "$@"


### PR DESCRIPTION
`docker-entrypoint.sh` runs `python manage.py makemigrations` as root, which also creates django's file chache dir (`/var/tmp/django_cache`). Since UWSGI is running with dropped privileges (UID 1000, GID 2000) we need to change the cache dir ownership so that uwsgi can read/write it.