### PR TITLE
Remove Postgres idiom to improve DB agnosticism

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -126,7 +126,7 @@ class Report(models.Model):
         """
         return {
             "domain_cnt" : Report.objects.filter(
-                    report_type=report_type).distinct("domain").count(),
+                    report_type=report_type).values("domain").distinct().count(),
             "report_cnt" : Report.objects.filter(
                     report_type=report_type).count(),
             "message_cnt" : Record.objects.filter(


### PR DESCRIPTION
This PR suggests @MASHtm's database agnosticism patch for inclusion
in dmarc-viewer/dmarc-viewer. (I have not yet tested the patch, but
it makes sense from a first look.)

@MASHtm notes about the patch:

> I detected another call which ends up in a postgre specific
> "DISTINCT ON" select. (...) With this small change it should work
> on all DB backends.

Thank you!