### PR TITLE
Install psycopg2 via pip, not apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ RUN set -ex \
             pcre-dev \
             postgresql-dev \
             libpq \
-            py-psycopg2 \
             cairo-dev \
-    && pip install -U pip \
+    && pip install -U pip psycopg2 \
     && pip install --no-cache-dir -r /requirements.txt \
     && pip install --no-cache-dir uwsgi \
     && find /usr/local \


### PR DESCRIPTION
Python 2 has been (mostly) dropped from alpine, due to Python 2 being EOL.

While a proper solution is to port this to Python 3, that's a bit beyond
what I have time for currently, so do the simple thing and install
psycopg2 via pip (which still carries it) rather than apk (which
doesn't).